### PR TITLE
*: check effective UID instead of real UID

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -19,7 +19,7 @@ use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 
 use error_chain::{bail, ChainedError};
-use users::get_current_uid;
+use users::get_effective_uid;
 
 use crate::errors::{Result, ResultExt};
 
@@ -79,7 +79,7 @@ fn ensure_safe_permissions(path: &Path) -> Result<()> {
 
     // owned by user or root
     let uid = metadata.uid();
-    if uid != 0 && uid != get_current_uid() {
+    if uid != 0 && uid != get_effective_uid() {
         bail!("bad ownership on {}: {}", path.display(), uid);
     }
 
@@ -218,7 +218,7 @@ mod tests {
 
     #[test]
     fn test_read_keys() {
-        if get_current_uid() == 0 {
+        if get_effective_uid() == 0 {
             panic!("can't run tests as root");
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,7 @@ fn run() -> Result<()> {
 mod tests {
     use super::*;
 
-    use users::{get_current_uid, get_current_username};
+    use users::{get_current_username, get_effective_uid};
 
     fn wrap_switch_user(username: &str) -> Result<User> {
         switch_user(&OsString::from(username)).map(|(u, _g)| u)
@@ -98,7 +98,7 @@ mod tests {
 
     #[test]
     fn test_switch_user() {
-        if get_current_uid() == 0 {
+        if get_effective_uid() == 0 {
             panic!("can't run tests as root");
         }
         assert_eq!(


### PR DESCRIPTION
`ensure_safe_permissions()` was improperly failing when run as root for a non-root user, since it was checking for the real UID (0) rather than the UID of the user we'd switched to.

Also switch the tests to `get_effective_uid()`, which is likewise what we meant.