### PR TITLE
keys: skip FIFOs rather than blocking indefinitely

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "cc"
+version = "1.0.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,6 +62,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "nix"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "void",
 ]
 
 [[package]]
@@ -126,6 +145,7 @@ version = "0.1.2-alpha.0"
 dependencies = [
  "clap",
  "error-chain",
+ "nix",
  "tempfile",
  "users",
 ]
@@ -174,6 +194,12 @@ name = "version_check"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,5 @@ error-chain = { version = "0.12", default-features = false }
 users = "0.10"
 
 [dev-dependencies]
+nix = "0.17"
 tempfile = "3"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,5 +17,6 @@ use error_chain::error_chain;
 error_chain! {
     foreign_links {
         Io(std::io::Error);
+        Nix(nix::Error) #[cfg(test)];
     }
 }


### PR DESCRIPTION
We can't open a FIFO and then check its type afterward, since opening for reading will block when the FIFO has no writers.  Move file type check earlier in `try_read_key_file()`.