### PR TITLE
github: release checklist cleanups

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -45,10 +45,9 @@ Push access to the upstream repository is required in order to publish the new t
 - [ ] get the PR reviewed, approved and merged
 
 - publish the artifacts (tag and crate):
-  - [ ] `git push ${UPSTREAM_REMOTE} v${RELEASE_VER}`
-  - [ ] make sure the upstream tag matches the local tag: `git fetch --tags --verbose ${UPSTREAM_REMOTE} 2>&1 | grep ${RELEASE_VER}`
   - [ ] `git checkout v${RELEASE_VER}`
-  - [ ]  make sure the tag is what you intend to release; if so this will show an empty output: `git diff release-${RELEASE_VER}~1 v${RELEASE_VER}`
+  - [ ] verify that `grep "^version = \"${RELEASE_VER}\"$" Cargo.toml` produces output
+  - [ ] `git push ${UPSTREAM_REMOTE} v${RELEASE_VER}`
   - [ ] `cargo publish`
 
 - assemble vendor archive:


### PR DESCRIPTION
Reduce the diff with coreos-installer.  See https://github.com/coreos/coreos-installer/pull/257.