### PR TITLE
release-checklist: updates to the release instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -30,7 +30,7 @@ Push access to the upstream repository is required in order to publish the new t
   - [ ] `RELEASE_VER=x.y.z`
   - [ ] `UPSTREAM_REMOTE=origin`
 
-:warning:: `UPSTREAM_REMOTE` should reference the locally configured remote that points to the upstream git repository.
+:warning:: `UPSTREAM_REMOTE` should reference the locally configured remote that points to the upstream git repository i.e. `git@github.com:coreos/ssh-key-dir.git`.
 
 - create release commits on a dedicated branch and tag it:
   - [ ] `git checkout -b release-${RELEASE_VER}`
@@ -55,7 +55,7 @@ Push access to the upstream repository is required in order to publish the new t
   - [ ] `tar -czf target/ssh-key-dir-${RELEASE_VER}-vendor.tar.gz vendor`
 
 - publish this release on GitHub:
-  - [ ] open a web browser and [create a GitHub Release](https://github.com/coreos/ssh-key-dir/releases/new) for the tag above
+  - [ ] find the new tag in the [GitHub tag list](https://github.com/coreos/ssh-key-dir/tags) and click the triple dots menu, and create a release for it
   - [ ] write a short changelog (i.e. re-use the PR content)
   - [ ] upload `target/ssh-key-dir-${RELEASE_VER}-vendor.tar.gz`
   - [ ] record digests of local artifacts:


### PR DESCRIPTION
This will update the release checklist step for publishing a release and clarify the `UPSTREAM_REMOTE` keyword.