### PR TITLE
ci: adapt to new buildroot image

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,7 +1,21 @@
 // Documentation: https://github.com/coreos/coreos-ci/blob/master/README-upstream-ci.md
 
+buildPod {
+    checkout scm
+    stage("Build") {
+        shwrap("make && make install DESTDIR=install")
+        stash name: 'build', includes: 'install/**'
+    }
+    // XXX: uncomment once we have
+    // https://github.com/coreos/fedora-coreos-config/pull/917
+    // stage("Unit Test") {
+    //     shwrap("cargo test")
+    // }
+}
+
 cosaPod(buildroot: true) {
     checkout scm
 
-    fcosBuild(make: true)
+    unstash name: 'build'
+    fcosBuild(overlays: ["install"])
 }


### PR DESCRIPTION
Similar to coreos/ignition#1182 as a result of
coreos/fedora-coreos-config#740.

As a bonus, we now get a clear separate stage for building. Add a stage
for running unit tests, but keep it commented out for now and we'll
circle back to it when it's cleaner to do once we have:

coreos/fedora-coreos-config#917

GitHub Actions covers unit tests anyway.

