### PR TITLE
workflows: bump toolchains; restrict repository access

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   # Minimum supported Rust version (MSRV)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,9 +9,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
   # Minimum supported Rust version (MSRV)
-  ACTIONS_MSRV_TOOLCHAIN: 1.44.0
+  ACTIONS_MSRV_TOOLCHAIN: 1.49.0
   # Pinned toolchain for linting
-  ACTIONS_LINTS_TOOLCHAIN: 1.52.0
+  ACTIONS_LINTS_TOOLCHAIN: 1.53.0
 
 jobs:
   tests-stable:


### PR DESCRIPTION
OCP 4.9 has Rust 1.49, which isn't relevant for this repo, but stay consistent with our other Rust projects.