### PR TITLE
release-checklist: clarify crates.io access

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -16,8 +16,8 @@ This guide requires:
  * `cargo-release` (suggested: `cargo install -f cargo-release`)
  * A verified account on crates.io
  * Write access to this GitHub project
- * Upload access to this project on GitHub and crates.io
- * Membership in the [Fedora CoreOS Crates Owners group](https://github.com/orgs/coreos/teams/fedora-coreos-crates-owners/members)
+ * Upload access to this project on GitHub
+ * Membership in the [Fedora CoreOS Crates Owners group](https://github.com/orgs/coreos/teams/fedora-coreos-crates-owners/members) which will give you upload access to crates.io
 
 ## Release checklist
 


### PR DESCRIPTION
The before-last bullet mentions `crates.io`, but for most people, access
to it will be through the "Fedora CoreOS Crates Owners" GitHub group,
which is the very next bullet. Shift mention of `crates.io` there.