### PR TITLE
templates/release-checklist: delete all `.a` files from vendor dir

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -53,7 +53,7 @@ Push access to the upstream repository is required in order to publish the new t
 
 - assemble vendor archive:
   - [ ] `cargo vendor target/vendor`
-  - [ ] `rm -r target/vendor/winapi*gnu*/lib/*.a`
+  - [ ] `find target/vendor -name '*.a' -delete`
   - [ ] `tar -czf target/ssh-key-dir-${RELEASE_VER}-vendor.tar.gz -C target vendor`
 
 - publish this release on GitHub:


### PR DESCRIPTION
Our vendor tarball should never need to include compiled static libs, so be sure to delete them all.

No functional change currently; just future-proofing.