### PR TITLE
cargo: ssh-key-dir release 0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-key-dir"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "AuthorizedKeysCommand wrapper to read ~/.ssh/authorized_keys.d"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Changes:

-  Require Rust ≥ 1.58
-  Require clap ≥ 3.1
-  Remove Windows binaries from vendor archive
