### PR TITLE
Cargo.toml: update description to be same as rpm spec file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 rust-version = "1.58.0"
 exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
-description = "AuthorizedKeysCommand wrapper to read ~/.ssh/authorized_keys.d"
+description = "sshd AuthorizedKeysCommand to read ~/.ssh/authorized_keys.d"
 readme = "README.md"
 version = "0.1.4"
 


### PR DESCRIPTION
Noticed an inconsistency with description of packaging and cargo.toml file. 