### PR TITLE
cargo: stop enabling LTO in release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,6 @@ tag-message = "ssh-key-dir v{{version}}"
 name = "ssh-key-dir"
 path = "src/main.rs"
 
-[profile.release]
-lto = true
-
 [dependencies]
 anyhow = ">= 1.0.38, < 2"
 clap = { version = ">= 3.1, < 4", default-features = false, features = ["std", "cargo"] }


### PR DESCRIPTION
It's not yet the upstream default, and it's caused miscompilations in the past on non-x86 builds.  We don't especially need the extra optimization and this is security-sensitive code, so let's be conservative and drop it.