### PR TITLE
Move away from deprecated `users` to `uzers`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ dependencies = [
  "clap",
  "nix",
  "tempfile",
- "users",
+ "uzers",
 ]
 
 [[package]]
@@ -200,10 +200,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "users"
-version = "0.11.0"
+name = "uzers"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
+checksum = "76d283dc7e8c901e79e32d077866eaf599156cbf427fffa8289aecc52c5c3f63"
 dependencies = [
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = ">= 1.0.38, < 2"
 clap = { version = "4", default-features = false, features = ["std", "cargo", "help", "string", "usage"] }
-users = ">= 0.10, < 0.12"
+uzers = ">= 0.10, < 0.12"
 
 [dev-dependencies]
 nix = ">= 0.17, < 0.27"

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,6 +4,7 @@
 
 Changes:
 
+- Replace deprecated dependency users by uzers
 
 
 ## ssh-key-dir 0.1.4 (2022-09-27)

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -19,7 +19,7 @@ use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
-use users::get_effective_uid;
+use uzers::get_effective_uid;
 
 const KEYS_SUBDIR: &str = "authorized_keys.d";
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,9 +17,9 @@ use std::io;
 
 use anyhow::{Context, Result};
 use clap::{crate_version, value_parser, Arg, Command};
-use users::os::unix::UserExt;
-use users::switch::{switch_user_group, SwitchUserGuard};
-use users::{get_current_username, get_user_by_name, User};
+use uzers::os::unix::UserExt;
+use uzers::switch::{switch_user_group, SwitchUserGuard};
+use uzers::{get_current_username, get_user_by_name, User};
 
 use crate::keys::read_keys;
 
@@ -87,7 +87,7 @@ fn main() -> Result<()> {
 mod tests {
     use super::*;
 
-    use users::{get_current_username, get_effective_uid};
+    use uzers::{get_current_username, get_effective_uid};
 
     fn wrap_switch_user(username: &str) -> Result<User> {
         switch_user(&OsString::from(username)).map(|(u, _g)| u)


### PR DESCRIPTION
It hasn't been updated in years. Move to the adopted crate `uzers`.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2214223
Related: https://rustsec.org/advisories/RUSTSEC-2023-0040.html
Related: https://github.com/ogham/rust-users/issues/54