### PR TITLE
cargo: ssh-key-dir release 0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-key-dir"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ exclude = ["/.cci.jenkinsfile", "/.github", "/.gitignore"]
 authors = [ "Benjamin Gilbert <bgilbert@redhat.com>" ]
 description = "sshd AuthorizedKeysCommand to read ~/.ssh/authorized_keys.d"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
Changes:
- Replace deprecated dependency users by uzers
- Cargo.toml: bump MSRV to 1.75.0
- docs/release-notes: update for release 0.1.5

See https://github.com/coreos/ssh-key-dir/issues/176